### PR TITLE
修复php8兼容性问题：libxml_disable_entity_loader() is deprecated

### DIFF
--- a/src/Kernel/Support/XML.php
+++ b/src/Kernel/Support/XML.php
@@ -14,11 +14,11 @@ class XML
      */
     public static function parse($str)
     {
-        $backup = libxml_disable_entity_loader(true);
+        PHP_MAJOR_VERSION < 8 && $backup = libxml_disable_entity_loader(true);
 
         $result = self::normalize(simplexml_load_string(self::sanitize($str), 'SimpleXMLElement', LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS));
 
-        libxml_disable_entity_loader($backup);
+        PHP_MAJOR_VERSION < 8 && libxml_disable_entity_loader($backup);
 
         return $result;
     }


### PR DESCRIPTION
相同的问题，根据这个https://github.com/w7corp/easywechat/commit/ea75d4637ed416e2d78e925f983f92f4896e07a3，修复本库的问题。